### PR TITLE
Status mag geen ex-member of just-joined zijn

### DIFF
--- a/bbcodegenerator.php
+++ b/bbcodegenerator.php
@@ -154,6 +154,7 @@ LEFT JOIN 3_updates AS yesterday
     AND yesterday.seqnum = (SELECT MAX(seqnum) FROM 3_updates) - 1
 WHERE
     users.status != "ex-member"
+    AND users.status != "just-joined"
 GROUP BY
     users.username
 ORDER BY


### PR DESCRIPTION
Ik heb in de query (regel 157) een extra statement toegevoegd die ervoor zorgt dat de leden met status ex-member of just-joined niet mee worden genomen in het resultaat.
